### PR TITLE
Add MobileUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ A curated list of awesome Kotlin frameworks, libraries, documents and other reso
 - [kotlin-compile-testing](https://github.com/tschuchortdev/kotlin-compile-testing) - A library for testing Kotlin and Java annotation processors, compiler plugins and code generation
 - [koin](https://github.com/InsertKoinIO/koin) - A pragmatic lightweight dependency injection framework for Kotlin developers. Written in pure Kotlin, using functional resolution only: no proxy, no code generation, no reflection. 
 - [firebase-kotlin-sdk](https://github.com/GitLiveApp/firebase-kotlin-sdk) - A Kotlin-first Multiplatform SDK for Firebase supporting iOS, Android & Web. 
-- [graphql-kotlin-toolkit](https://github.com/AurityLab/graphql-kotlin-toolkit) - GraphQL toolkit for Kotlin (includes code generator and spring boot integration) 
+- [graphql-kotlin-toolkit](https://github.com/AurityLab/graphql-kotlin-toolkit) - GraphQL toolkit for Kotlin (includes code generator and spring boot integration)
+- [MobileUI](https://mobileui.dev) - Cross-platform framework for developing mobile apps (iOS, Android) with native UI in Java and Kotlin. 
 
 ## Samples
 


### PR DESCRIPTION
Hi, I'd like to add [MobileUI](https://mobileui.dev) to the list.

It's a framework for Cross-Platform Mobile Development in Kotlin (or Java).