### PR TITLE
Add mutflow - Kotlin K2 mutation testing compiler plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,6 +668,7 @@ A curated list of awesome Kotlin frameworks, libraries, documents and other reso
 - [detekt-hint](https://github.com/mkohm/detekt-hint) - Detection of design principle violations as a plugin to detekt.
 - [kotlin-jupyter](https://github.com/Kotlin/kotlin-jupyter) - Kotlin kernel for Jupyter/IPython
 - [StringSwitch](https://stringswitch.com) - Easily convert Android strings.xml format to iOS .strings files and vice versa.
+- [mutflow](https://github.com/anschnapp/mutflow) - Lightweight mutation testing that compiles once and runs directly in your test suite - implemented as a Kotlin K2 compiler plugin.
 
 ## Resources
 - [Kotlin coding puzzles](https://github.com/igorwojda/kotlin-coding-puzzle) - Set of programming challenges thats helps to improve whiteboard coding and problem-solving skills.


### PR DESCRIPTION
Adds https://github.com/anschnapp/mutflow to the Libraries list.

mutflow is a lightweight mutation testing tool for Kotlin that compiles once and runs directly in your existing test suite, implemented as a K2 compiler plugin using the mutant schemata technique.