### PR TITLE
Add WebAuthn Kotlin Multiplatform library

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A curated list of awesome Kotlin frameworks, libraries, documents and other reso
 - [kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines) - Library support for Kotlin coroutines 
 - [timber](https://github.com/JakeWharton/timber) - A logger with a small, extensible API which provides utility on top of Android's normal Log class.
 - [ktor](https://github.com/ktorio/ktor) - Framework for quickly creating connected applications in Kotlin with minimal effort
+- [webauthn-kotlin-multiplatform](https://github.com/szijpeter/webauthn-kotlin-multiplatform) - Standards-first Kotlin Multiplatform building blocks for WebAuthn and passkey integrations across Ktor/JVM, Android, and iOS.
 - [FlowMVI](https://github.com/respawn-app/FlowMVI) - A Kotlin Multiplatform architectural framework based on coroutines with an extensive feature set, powerful plugin system and a rich DSL.
 - [okio](https://github.com/square/okio) - A modern I/O library for Android, Kotlin, and Java.
 - [TranslationPlugin](https://github.com/YiiGuxing/TranslationPlugin) - :electric_plug:Translation plugin for IntelliJ based IDEs/Android Studio


### PR DESCRIPTION
This adds `webauthn-kotlin-multiplatform` to the libraries list.

It is an open-source Kotlin Multiplatform library for WebAuthn/passkey integrations across Ktor/JVM backends, Android, and iOS.

Repo: https://github.com/szijpeter/webauthn-kotlin-multiplatform