### PR TITLE
Add Compose BOM Changelog to Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,6 +679,7 @@ A curated list of awesome Kotlin frameworks, libraries, documents and other reso
 - [Curated Kotlin Resources](https://hackr.io/tutorials/learn-kotlin)
 - [Kotlin: An Illustrated Guide](https://typealias.com/start/) - An illustrated guide to learning Kotlin..
 - [Composables.com](https://composables.com) – Components for Compose Multiplatform and Jetpack Compose with images and code samples.
+- [Compose BOM Changelog](https://compose-bom.com) - Diff viewer for Jetpack Compose BOM versions with aggregated library release notes.
 
 ## Others
 - [kotlin-for-android-developers-zh](https://wangjiegulu.gitbooks.io/kotlin-for-android-developers-zh/content/)


### PR DESCRIPTION
Adds [compose-bom.com](https://compose-bom.com) to the Resources section.

It's an open-source web tool that lets you pick any two Jetpack Compose BOM versions and see the aggregated release notes (new features / bug fixes / API changes) for every library that changed between them, on a single shareable page.

Fits the Resources section alongside Composables.com — a web reference for Compose developers, complementary use case.

- Site: https://compose-bom.com
- Example: https://compose-bom.com/?from=2026.03.00&to=2026.05.01
- Source: https://github.com/keymusicman/compose-bom-changelog
- License: MIT
- Static site, no backend; data refreshed weekly via GitHub Actions

<img width="600" alt="image" src="https://github.com/user-attachments/assets/e43f796a-c63b-4523-bf81-e2d6bdda616f" />
