### PR TITLE
Add lirp library

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ A curated list of awesome Kotlin frameworks, libraries, documents and other reso
 - [VPNHotspot](https://github.com/Mygod/VPNHotspot) - Share your VPN connection over hotspot or repeater! (root required)
 - [TimberX](https://github.com/naman14/TimberX) - Material theme music player that works across all form factors (phones, wear, auto, cast, assistant) and uses latest tools (Kotlin, Architecture components, Room, Databinding) 
 - [jasync-sql](https://github.com/jasync-sql/jasync-sql) - Java & Kotlin Async DataBase Driver for MySQL and PostgreSQL written in Kotlin
+- [lirp](https://github.com/octaviospain/lirp) - Lightweight Reactive Persistence - Elegant object thinking with Domain Driven Design to persist objects reactively.
 - [tachiyomi-extensions](https://github.com/tachiyomiorg/tachiyomi-extensions) - Source extensions for the Tachiyomi app.
 - [CatLoadingView](https://github.com/Rogero0o/CatLoadingView) - Android CatLoadingView
 - [input-mask-android](https://github.com/RedMadRobot/input-mask-android) - User input masking library repo.


### PR DESCRIPTION
## Summary

Added [lirp](https://github.com/octaviospain/lirp/) to the Libraries section.

lirp is a Lightweight Reactive Persistence library that provides elegant object thinking with Domain Driven Design principles for reactively persisting objects.

## Key Features

- Transparent SQL persistence — entities and property changes automatically sync with database
- Entity-first reactivity — properties notify subscribers on assignment with zero overhead
- DDD aggregate references with compiler-enforced cardinality annotations
- Type-safe Query DSL with automatic index routing
- Soft delete support with configurable visibility
- Optimistic locking with conflict detection
- JSON persistence with debounced file writes
- Secondary indexes for O(1) equality lookups
- JavaFX integration with observable collections
- Kafka event publishing through transactional outbox
- Convention-over-configuration KSP code generation