### PR TITLE
Add "Kotlin SWE-bench" to README as a new project

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,6 +687,7 @@ A curated list of awesome Kotlin frameworks, libraries, documents and other reso
 - [Kotlin-Website-CN](https://github.com/cctanfujun/kotlin-web-site-cn)
 - [Kotlin Reference in Chinese](https://www.kotlincn.net/)
 - [jetpack compose](https://blog.canopas.com/jetpack-compose-mvvm-state-management-in-a-simple-way-4c632fa6f554) - We all want to simplify state management. Be it a life or application or a screen, limiting mutable states that a component can be in, benefits everyone.
+- [Kotlin SWE-bench](https://github.com/Kotlin/kotlin-swe-bench) - A Kotlin software-engineering benchmark for evaluating coding agents.
 
 ## License
 


### PR DESCRIPTION
**Add Kotlin SWE-bench to the list of awesome project**

Kotlin SWE-bench is a benchmark for evaluating coding agents (106 tasks across 9 open-source Kotlin repos), a useful reference resource for the Kotlin community.
